### PR TITLE
Remove deprecated `display-info`-goal from maven enforcer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -503,7 +503,6 @@
           <execution>
             <id>display-info</id>
             <goals>
-              <goal>display-info</goal>
               <goal>enforce</goal>
             </goals>
             <phase>validate</phase>


### PR DESCRIPTION
Remove deprecated `<goal>display-info</goal>` from enforcer
According to [maven-enforcer-plugin](https://maven.apache.org/enforcer/maven-enforcer-plugin/display-info-mojo.html) this is deprecated. And in plugins we see it somewhat double currently:
![grafik](https://user-images.githubusercontent.com/22742658/222951396-bf523a6e-fd13-449f-bd03-d9261bff77b0.png)
